### PR TITLE
Marked as stable

### DIFF
--- a/.changeset/tangy-gifts-invent.md
+++ b/.changeset/tangy-gifts-invent.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-ember-hbs-tag": major
+---
+
+Marked as stable


### PR DESCRIPTION
`prettier-plugin-ember-hbs-tag` has been used in several production projects for a couple of months.